### PR TITLE
raspi32armv6 support

### DIFF
--- a/syscall.c
+++ b/syscall.c
@@ -36,6 +36,15 @@ pid_t getpid_syscall(void)
 		 *       or a symbolic constant. */
 		: "0"(SYSCALL_MASK | 0x0000)
 		: "rcx", "r11"
+#elif defined(__ARM_ARCH_6__)
+		// found on Raspberry Pi 32bit Raspberry OS compatibility mode
+		  "mov r7,%1\n\t"
+		  "swi #0x00\n\t"
+		  "mov %0, r0"
+		: "=r"(res)
+		/* TODO: replace 0x0000 below with the syscall number
+		*       or a symbolic constant. */
+		: "0"(SYSCALL_MASK | 0x0000)
 #else
 #error Unsupported Architecture. Send a PR to add support!
 #endif


### PR DESCRIPTION
Raspberry Pi support, only for armv6 devices, so newer Raspberry Pis have to run with a 32bit version of RaspberryPiOS.
thanks to @LuckiestOne23, @PonderKoKo